### PR TITLE
Detect errors in bulk response

### DIFF
--- a/stash/es/writer.go
+++ b/stash/es/writer.go
@@ -54,8 +54,22 @@ func (w *Writer) execute(vals []interface{}) {
 		req := elastic.NewBulkIndexRequest().Index(pair.index).Type(w.docType).Doc(pair.val)
 		bulk.Add(req)
 	}
-	_, err := bulk.Do(context.Background())
+	resp, err := bulk.Do(context.Background())
+
 	if err != nil {
 		logx.Error(err)
+		return
+	}
+
+	// bulk error in docs will report in response items
+	if resp.Errors {
+		for _, imap := range resp.Items {
+			for _, item := range imap {
+				if item.Error == nil {
+					continue
+				}
+				logx.Error(item.Error)
+			}
+		}
 	}
 }


### PR DESCRIPTION
When bulking of indexing multiple docs, errors like `mapper_parsing_exception failed to parse field ...`  will not return via err directly in `BulkService.Do` call. Instead they will be returned in `BulkResponse.Items`. 

Detect those errors as well :)